### PR TITLE
Fix some issues

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,17 +1,20 @@
-pkgbase = gnabel
+pkgbase = gnabel-git
 	pkgdesc = A translation app for GTK environments based on Google Translate
-	pkgver = 0.0.0
-	pkgrel = 2
+	pkgver = 57ff9c3
+	pkgrel = 1
 	url = https://github.com/gi-lom/gnabel
 	arch = any
 	license = GPL-3.0
+	makedepends = git
 	depends = python>=3
 	depends = python-pyperclip
 	depends = python-gobject
 	depends = python-googletrans
 	depends = python-gtts
 	depends = python-pydub
-	source = https://github.com/gi-lom/gnabel/archive/57ff9c3d3631b04ddb8369e31ad2cfe46ec9099f.zip
+	provides = gnabel
+	conflicts = gnabel
+	source = gnabel::git+https://github.com/gi-lom/gnabel
 	sha512sums = SKIP
 
-pkgname = gnabel
+pkgname = gnabel-git

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,8 @@
 # Maintainer: Hoàng Văn Khải <hvksmr1996@gmail.com>
 
-set -o errexit -o pipefail
-
 pkgname='gnabel'
-pkgver='0.0.0'
-pkgrel='2'
+pkgver=57ff9c3
+pkgrel=1
 pkgdesc='A translation app for GTK environments based on Google Translate'
 arch=('any')
 depends=(
@@ -15,16 +13,21 @@ depends=(
   'python-gtts' # aur only
   'python-pydub' # aur only
 )
+makedepends=('git')
 url='https://github.com/gi-lom/gnabel'
 license=('GPL-3.0')
-_git_ref='57ff9c3d3631b04ddb8369e31ad2cfe46ec9099f'
 source=(
-  "https://github.com/gi-lom/gnabel/archive/$_git_ref.zip"
+  "gnabel::git+https://github.com/gi-lom/gnabel"
 )
 sha512sums=('SKIP')
 
+pkgver() {
+  cd "$srcdir/gnabel"
+  git describe --long --tags --always | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
 package() {
-  cd "gnabel-$_git_ref"
+  cd "$srcdir/gnabel"
 
   msg2 'Installing LICENSE'
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,6 +14,8 @@ depends=(
   'python-pydub' # aur only
 )
 makedepends=('git')
+provides=('gnabel')
+conflicts=('gnabel')
 url='https://github.com/gi-lom/gnabel'
 license=('GPL-3.0')
 source=(

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hoàng Văn Khải <hvksmr1996@gmail.com>
 
-pkgname='gnabel'
+pkgname='gnabel-git'
 pkgver=57ff9c3
 pkgrel=1
 pkgdesc='A translation app for GTK environments based on Google Translate'


### PR DESCRIPTION
- Use git instead of zip because then we can safely skip checksums.
- Use dynamic pkgver because no stable build is out, so this is technically a git package.
- Remove set at the beginning. It's useful for debugging but not necessary here because there's nothing error-prone.